### PR TITLE
#19 fix: fixed split() bug caused by different line separator on Windows (used lines() instead)

### DIFF
--- a/src/search/openings.rs
+++ b/src/search/openings.rs
@@ -30,7 +30,7 @@ fn line_to_tuple(line: &str) -> Option<(String, u64)> {
 
 impl OpeningBook {
     pub fn new() -> OpeningBook {
-        let opening_lines: Vec<&str> = OPENINGS_FILE.split('\n').collect();
+        let opening_lines: Vec<&str> = OPENINGS_FILE.lines().collect();
         let map: HashMap<String, u64> = opening_lines
             .iter()
             .filter_map(|&line| line_to_tuple(line))

--- a/src/ugi.rs
+++ b/src/ugi.rs
@@ -295,7 +295,7 @@ impl UgiEngine {
             Err(e) => {
                 println!(
                     "info error \"{}\"",
-                    e.to_string().split('\n').next().unwrap()
+                    e.to_string().lines().next().unwrap()
                 );
             }
         }


### PR DESCRIPTION
Resolves #19 